### PR TITLE
feat: add install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     description="A Python library for analysis of electrophysiological data",
     license="BSD",
     url="https://github.com/NeuralEnsemble/pyelectro",
+    install_requires=["numpy", "scipy", "matplotlib"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
To ensure that these are pulled in when pyelectro is installed using
pip.